### PR TITLE
chore: Update README and setup for package renaming; add GitHub Actions workflow for PyPI publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    
+    - name: Build package
+      run: python -m build
+    
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # pass-cli
 
+[![Tests](https://github.com/umuttopalak/pass-cli/actions/workflows/test.yml/badge.svg)](https://github.com/umuttopalak/pass-cli/actions/workflows/test.yml)
+[![PyPI version](https://badge.fury.io/py/password-cli.svg)](https://badge.fury.io/py/password-cli)
+[![Python versions](https://img.shields.io/pypi/pyversions/password-cli.svg)](https://pypi.org/project/password-cli/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 A secure command-line password manager with sudo authentication.
 
 ## Features
@@ -14,7 +19,7 @@ A secure command-line password manager with sudo authentication.
 ## Installation
 
 ```bash
-pip install pass-cli
+pip install password-cli
 ```
 
 ## Quick Start

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 # Project metadata
-PROJECT_NAME = "pass-cli"
+PROJECT_NAME = "password-cli"
 VERSION = "0.1.0"
 AUTHOR = "Umut Topalak"
 AUTHOR_EMAIL = "umuttopalak@hotmail.com"


### PR DESCRIPTION


- Changed project name from 'pass-cli' to 'password-cli' in README.md and setup.py.
- Added badges for tests, PyPI version, Python compatibility, and license in README.md.
- Introduced a new GitHub Actions workflow for automated publishing to PyPI on version tags.