### PR TITLE
feat: Enhance password management CLI commands

### DIFF
--- a/pass_cli/commands/generate.py
+++ b/pass_cli/commands/generate.py
@@ -12,44 +12,39 @@ from ..utils import check_initialized, check_sudo, generate_strong_password
 @click.option('--no-copy', is_flag=True, help='Show password in terminal instead of copying to clipboard')
 def generate(length: int, service: str, username: str, no_copy: bool) -> None:
     """Generate a secure random password"""
-    if not check_sudo():
-        click.echo(click.style("✗ Authentication required! Please run 'pass-cli auth' first.", fg="red"))
-        raise click.Abort()
-
-    if length < 8:
-        click.echo(click.style("Warning: Password length should be at least 8 characters", fg="yellow"))
+    if service and not check_sudo():
+        click.echo(click.style(
+            "✗ Authentication required! Please run 'pass-cli auth' first.", fg="red"))
         return
 
-    final_password = generate_strong_password(length=length)
+    if service and not check_initialized():
+        click.echo(click.style(
+            "✗ Password manager not initialized! Please run 'pass-cli init' first.", 
+            fg="red"))
+        return
 
-    if service and username:
-        try:
-            if not check_initialized():
-                click.echo(click.style("Password manager not initialized. Please run 'pass-cli init' first.", fg="red"))
-                raise click.Abort()
+    try:
+        password = generate_strong_password(length)
 
-            stored_key = PasswordManager.get_stored_key()
-            if not stored_key:
-                encryption_key = click.prompt('Enter encryption key', hide_input=True)
-            else:
-                encryption_key = stored_key
+        if service and username:
+            encryption_key = PasswordManager.get_stored_key()
+            if not encryption_key:
+                click.echo(click.style(
+                    "✗ No encryption key found! Please run 'pass-cli init' first.", fg="red"))
+                return
 
-            try:
-                pm = PasswordManager(encryption_key)
-                pm.store_password(service, username, final_password)
-                click.echo(click.style(f"Generated and stored password for {service}", fg="green"))
-            except ValueError:
-                click.echo(click.style("Invalid encryption key", fg="red"))
-                raise click.Abort()
-        except Exception as e:
-            click.echo(click.style(f"Error storing password: {str(e)}", fg="red"))
-            raise click.Abort()
+            password_manager = PasswordManager(encryption_key)
+            password_manager.store_password(service, username, password)
+            click.echo(click.style(
+                f"✓ Generated and stored password for {service}", fg="green"))
 
-    if no_copy:
-        # Show password in terminal if --no-copy is used
-        click.echo(click.style("Generated password:", fg="green"))
-        click.echo(final_password)
-    else:
-        # Only copy to clipboard by default
-        pyperclip.copy(final_password)
-        click.echo(click.style("✓ Password copied to clipboard!", fg="green"))
+        if no_copy:
+            click.echo(click.style("Generated password:", fg="green"))
+            click.echo(password)
+        else:
+            pyperclip.copy(password)
+            click.echo(click.style("✓ Password copied to clipboard!", fg="green"))
+
+    except Exception as e:
+        click.echo(click.style(f"✗ {str(e)}", fg="red"))
+        return

--- a/pass_cli/commands/init.py
+++ b/pass_cli/commands/init.py
@@ -4,36 +4,41 @@ import string
 import click
 
 from ..database import PasswordManager
-from ..utils import generate_strong_password
+from ..utils import check_initialized, generate_strong_password
 
 
 @click.command()
 def init():
-    """Initialize the password manager with an encryption key.
-    
-    If no key is entered, a secure random key will be generated.
-    Make sure to save your encryption key - it cannot be recovered!
-    """
+    """Initialize the password manager"""
     try:
-        if PasswordManager()._has_encryption_key():
-            click.echo(click.style("Password manager is already initialized", fg="yellow"))
+        if check_initialized():
+            click.echo(click.style(
+                "✗ Password manager is already initialized!", fg="yellow"))
             return
 
-        click.echo("Enter encryption key (press Enter for a random secure key)")
-        key = click.prompt('Encryption key', hide_input=True, default='', show_default=False)
-        
-        if not key:
-            key = generate_strong_password(is_encryption_key=True)
-            click.echo(click.style("\nGenerated encryption key:", fg="green"))
-            click.echo(click.style(key, fg="yellow"))
-            click.echo(click.style("\n⚠️  IMPORTANT: Save this encryption key securely! You won't be able to recover it!", fg="red"))
-        else:
-            confirm = click.prompt('Confirm encryption key', hide_input=True)
-            if key != confirm:
-                click.echo(click.style("Error: Keys do not match", fg="red"))
-                raise click.Abort()
-        
-        pm = PasswordManager(key)
-        click.echo(click.style("\nPassword manager initialized successfully", fg="green"))
+        encryption_key = click.prompt(
+            "Enter encryption key (or press Enter to generate one)", 
+            default='', 
+            hide_input=True
+        )
+
+        if not encryption_key:
+            encryption_key = generate_strong_password(is_encryption_key=True)
+            click.echo(click.style(
+                "Generated secure encryption key.", fg="green"))
+
+        confirm_key = click.prompt(
+            "Confirm encryption key", 
+            hide_input=True
+        )
+
+        if encryption_key != confirm_key:
+            click.echo(click.style("✗ Encryption keys do not match!", fg="red"))
+            return
+
+        PasswordManager(encryption_key)
+        click.echo(click.style("✓ Password manager initialized successfully!", fg="green"))
+
     except Exception as e:
-        click.echo(click.style(f"Error initializing password manager: {str(e)}", fg="red")) 
+        click.echo(click.style(f"✗ {str(e)}", fg="red"))
+        return 

--- a/pass_cli/commands/retrieve.py
+++ b/pass_cli/commands/retrieve.py
@@ -1,31 +1,49 @@
-import os
-
 import click
+import pyperclip
 
 from ..database import PasswordManager
-from ..utils import check_sudo
+from ..utils import check_initialized, check_sudo
 
 
 @click.command()
 @click.option('--service', '-s', required=True, help='Service name')
 @click.option('--username', '-u', required=True, help='Username')
-def retrieve(service: str, username: str):
-    """Retrieve a password for a service"""
+@click.option('--no-copy', is_flag=True, help='Show password in terminal instead of copying to clipboard')
+def retrieve(service: str, username: str, no_copy: bool) -> None:
+    """Retrieve a stored password"""
     if not check_sudo():
-        click.echo(click.style("✗ Authentication required! Please run 'pass-cli auth' first.", fg="red"))
-        raise click.Abort()
+        click.echo(click.style(
+            "✗ Authentication required! Please run 'pass-cli auth' first.", fg="red"))
+        return
+
+    if not check_initialized():
+        click.echo(click.style(
+            "✗ Password manager not initialized! Please run 'pass-cli init' first.", 
+            fg="red"))
+        return
 
     try:
-        master_password = click.prompt('Enter master password', hide_input=True)
-        pm = PasswordManager(master_password)
-        password = pm.get_password(service, username)
-        
-        if password:
-            click.echo(click.style(f"Password for {service}:", fg="green"))
+        encryption_key = PasswordManager.get_stored_key()
+        if not encryption_key:
+            click.echo(click.style(
+                "✗ No encryption key found! Please run 'pass-cli init' first.", fg="red"))
+            return
+
+        password_manager = PasswordManager(encryption_key)
+
+        password = password_manager.get_password(service, username)
+        if password is None:
+            click.echo(click.style(
+                f"✗ No password found for {service} / {username}", fg="red"))
+            return
+
+        if no_copy:
+            click.echo(click.style("Retrieved password:", fg="green"))
             click.echo(password)
         else:
-            click.echo(click.style(f"No password found for {service} with username {username}", fg="yellow"))
-    except ValueError as e:
-        click.echo(click.style(f"Error: {str(e)}", fg="red"))
+            pyperclip.copy(password)
+            click.echo(click.style("✓ Password copied to clipboard!", fg="green"))
+
     except Exception as e:
-        click.echo(click.style(f"Error retrieving password: {str(e)}", fg="red"))
+        click.echo(click.style(f"✗ {str(e)}", fg="red"))
+        return

--- a/pass_cli/commands/store.py
+++ b/pass_cli/commands/store.py
@@ -3,25 +3,37 @@ import os
 import click
 
 from ..database import PasswordManager
-from ..utils import check_sudo
+from ..utils import check_initialized, check_sudo
 
 
 @click.command()
 @click.option('--service', '-s', required=True, help='Service name')
 @click.option('--username', '-u', required=True, help='Username')
 @click.option('--password', '-p', required=True, help='Password to store')
-def store(service: str, username: str, password: str):
+def store(service: str, username: str, password: str) -> None:
     """Store a password for a service"""
     if not check_sudo():
-        click.echo(click.style("✗ Authentication required! Please run 'pass-cli auth' first.", fg="red"))
-        raise click.Abort()
+        click.echo(click.style(
+            "✗ Authentication required! Please run 'pass-cli auth' first.", fg="red"))
+        return
+
+    if not check_initialized():
+        click.echo(click.style(
+            "✗ Password manager not initialized! Please run 'pass-cli init' first.", 
+            fg="red"))
+        return
 
     try:
-        master_password = click.prompt('Enter master password', hide_input=True)
-        pm = PasswordManager(master_password)
-        pm.store_password(service, username, password)
-        click.echo(click.style(f"Password stored successfully for {service}", fg="green"))
-    except ValueError as e:
-        click.echo(click.style(f"Error: {str(e)}", fg="red"))
+        encryption_key = PasswordManager.get_stored_key()
+        if not encryption_key:
+            click.echo(click.style(
+                "✗ No encryption key found! Please run 'pass-cli init' first.", fg="red"))
+            return
+
+        password_manager = PasswordManager(encryption_key)
+        password_manager.store_password(service, username, password)
+        click.echo(click.style("✓ Password stored successfully!", fg="green"))
+
     except Exception as e:
-        click.echo(click.style(f"Error storing password: {str(e)}", fg="red"))
+        click.echo(click.style(f"✗ {str(e)}", fg="red"))
+        return


### PR DESCRIPTION
Closes #3 
- Improved error handling and user feedback for commands: generate, init, list, retrieve, and store.
- Added checks for password manager initialization and encryption key presence across commands.
- Updated the generate command to handle password storage and display options more effectively.
- Refined the init command to ensure proper encryption key confirmation and generation.
- Enhanced the list command to provide clearer output for missing passwords and services.
- Updated the retrieve command to support displaying passwords in the terminal with a no-copy option.
- Improved the store command to ensure proper feedback on password storage success.

These changes enhance the overall user experience and reliability of the password management CLI.