### PR TITLE
refactor: Remove encryption key confirmation from init command

### DIFF
--- a/pass_cli/commands/init.py
+++ b/pass_cli/commands/init.py
@@ -27,15 +27,6 @@ def init():
             click.echo(click.style(
                 "Generated secure encryption key.", fg="green"))
 
-        confirm_key = click.prompt(
-            "Confirm encryption key", 
-            hide_input=True
-        )
-
-        if encryption_key != confirm_key:
-            click.echo(click.style("✗ Encryption keys do not match!", fg="red"))
-            return
-
         PasswordManager(encryption_key)
         click.echo(click.style("✓ Password manager initialized successfully!", fg="green"))
 


### PR DESCRIPTION
- Eliminated the confirmation step for the encryption key during password manager initialization.
- Simplified the user experience by directly initializing the PasswordManager with the provided encryption key.

This change streamlines the initialization process, enhancing usability for the password management CLI.