### PR TITLE
feat: Add password deletion functionality to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ List passwords for a specific service:
 pass-cli list -s github
 ```
 
+### Delete Passwords
+
+Delete a stored password (with confirmation):
+```bash
+pass-cli delete -s github -u johndoe
+```
+
+Delete a stored password without confirmation:
+```bash
+pass-cli delete -s github -u johndoe --force
+```
+
 ## Security Features
 
 - AES-256 encryption for all stored passwords
@@ -89,6 +101,8 @@ pass-cli list -s github
 - System keyring integration for encryption key storage
 - Sudo authentication requirement for all operations
 - Local storage only - no cloud sync for enhanced security
+- Safe deletion with confirmation mechanism
+
 
 ## Development Setup
 

--- a/pass_cli/cli.py
+++ b/pass_cli/cli.py
@@ -2,6 +2,7 @@ import click
 
 from .commands.auth import auth
 from .commands.auth_check import auth_check
+from .commands.delete import delete
 from .commands.generate import generate
 from .commands.init import init
 from .commands.list import list
@@ -33,12 +34,18 @@ class CustomHelpCommand(click.Group):
         formatter.write("      -u, --username     Username (required)\n")
         formatter.write("\n    pass-cli list         List saved passwords\n")
         formatter.write("      -s, --service      Filter passwords by service name\n")
+        formatter.write("\n    pass-cli delete       Delete a stored password\n")
+        formatter.write("      -s, --service      Service name (required)\n")
+        formatter.write("      -u, --username     Username (required)\n")
+        formatter.write("      -f, --force        Skip confirmation\n")
         formatter.write("\nExamples:\n")
         formatter.write("  pass-cli generate -l 16 -s github -u johndoe\n")
         formatter.write("  pass-cli store -s github -u johndoe -p mypassword\n")
         formatter.write("  pass-cli retrieve -s github -u johndoe\n")
         formatter.write("  pass-cli list\n")
         formatter.write("  pass-cli list -s github\n")
+        formatter.write("  pass-cli delete -s github -u johndoe\n")
+        formatter.write("  pass-cli delete -s github -u johndoe --force\n")
         formatter.write("\nOptions:\n")
         formatter.write("  --help  Show this message and exit.\n")
 
@@ -56,6 +63,7 @@ main.add_command(init)
 main.add_command(store)
 main.add_command(retrieve)
 main.add_command(list)
+main.add_command(delete)
 
 if __name__ == "__main__":
     main()

--- a/pass_cli/commands/delete.py
+++ b/pass_cli/commands/delete.py
@@ -1,0 +1,52 @@
+import click
+
+from ..database import PasswordManager
+from ..utils import check_initialized, check_sudo
+
+
+@click.command()
+@click.option('--service', '-s', required=True, help='Service name')
+@click.option('--username', '-u', required=True, help='Username')
+@click.option('--force', '-f', is_flag=True, help='Skip confirmation')
+def delete(service: str, username: str, force: bool) -> None:
+    """Delete a stored password"""
+    if not check_sudo():
+        click.echo(click.style(
+            "✗ Authentication required! Please run 'pass-cli auth' first.", fg="red"))
+        return
+
+    if not check_initialized():
+        click.echo(click.style(
+            "✗ Password manager not initialized! Please run 'pass-cli init' first.", 
+            fg="red"))
+        return
+
+    try:
+        encryption_key = PasswordManager.get_stored_key()
+        if not encryption_key:
+            click.echo(click.style(
+                "✗ No encryption key found! Please run 'pass-cli init' first.", fg="red"))
+            return
+
+        password_manager = PasswordManager(encryption_key)
+
+        if not password_manager.get_password(service, username):
+            click.echo(click.style(
+                f"✗ No password found for {service} / {username}", fg="red"))
+            return
+
+        if not force:
+            confirm = click.confirm(
+                f"Are you sure you want to delete the password for {service} / {username}?",
+                abort=True
+            )
+
+        password_manager.delete_password(service, username)
+        click.echo(click.style("✓ Password deleted successfully!", fg="green"))
+
+    except click.Abort:
+        click.echo(click.style("Operation cancelled.", fg="yellow"))
+        return
+    except Exception as e:
+        click.echo(click.style(f"✗ {str(e)}", fg="red"))
+        return 

--- a/pass_cli/database.py
+++ b/pass_cli/database.py
@@ -134,6 +134,24 @@ class PasswordManager:
                 return result
             return []
 
+    def delete_password(self, service_name: str, username: str) -> bool:
+        """Delete a password from the database
+
+        Args:
+            service_name: Name of the service
+            username: Username for the service
+
+        Returns:
+            bool: True if password was deleted, False if not found
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.cursor()
+            cursor.execute('''
+                DELETE FROM passwords 
+                WHERE service_name = ? AND username = ?
+            ''', (service_name, username))
+            return cursor.rowcount > 0
+
     @classmethod
     def get_stored_key(cls) -> str:
         """Get encryption key from keyring"""

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 # Project metadata
 PROJECT_NAME = "password-cli"
-VERSION = "0.1.5"
+VERSION = "0.1.6"
 AUTHOR = "Umut Topalak"
 AUTHOR_EMAIL = "umuttopalak@hotmail.com"
 DESCRIPTION = "A secure command-line password manager with sudo authentication"


### PR DESCRIPTION
- Introduced a new command to delete stored passwords with optional confirmation.
- Updated README.md to include usage instructions for the delete command.
- Bumped version to 0.1.6 in setup.py to reflect the new feature.
- Enhanced CLI help output to document the delete command and its options.

These changes improve the password management CLI by allowing users to securely delete passwords, enhancing overall usability and functionality.